### PR TITLE
Fix crash when selecting 'add' after 'empty'

### DIFF
--- a/app/src/main/java/com/example/android/recyclerplayground/fragments/RecyclerFragment.java
+++ b/app/src/main/java/com/example/android/recyclerplayground/fragments/RecyclerFragment.java
@@ -63,7 +63,7 @@ public abstract class RecyclerFragment extends Fragment implements AdapterView.O
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_add:
-                mAdapter.addItem(1);
+                mAdapter.addItem(0);
                 return true;
             case R.id.action_remove:
                 mAdapter.removeItem(0);


### PR DESCRIPTION
It was trying to insert at position 1 in the ArrayList, which isn't
valid when it's empty.