### PR TITLE
Fix crash when add after empty

### DIFF
--- a/app/src/main/java/com/example/android/recyclerplayground/adapters/SimpleAdapter.java
+++ b/app/src/main/java/com/example/android/recyclerplayground/adapters/SimpleAdapter.java
@@ -42,7 +42,7 @@ public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.VerticalIt
      * animations in addition to updating the view.
      */
     public void addItem(int position) {
-        if (position >= mItems.size()) return;
+        if (position > mItems.size()) return;
         
         mItems.add(position, generateDummyItem());
         notifyItemInserted(position);

--- a/app/src/main/java/com/example/android/recyclerplayground/fragments/RecyclerFragment.java
+++ b/app/src/main/java/com/example/android/recyclerplayground/fragments/RecyclerFragment.java
@@ -67,7 +67,7 @@ public abstract class RecyclerFragment extends Fragment implements AdapterView.O
             case R.id.action_add:
                 dialog = new NumberPickerDialog(getActivity());
                 dialog.setTitle("Position to Add");
-                dialog.setPickerRange(0, mAdapter.getItemCount()-1);
+                dialog.setPickerRange(0, mAdapter.getItemCount());
                 dialog.setOnNumberSelectedListener(new NumberPickerDialog.OnNumberSelectedListener() {
                     @Override
                     public void onNumberSelected(int value) {


### PR DESCRIPTION
App crashes when you select  'Add' after the 'Empty'.
I was fixed it. And, I have modified to be able to add.

Crash stacktrace
```
E/AndroidRuntime(22443): java.lang.IllegalArgumentException: maxValue must be >= 0
E/AndroidRuntime(22443):        at android.widget.NumberPicker.setMaxValue(NumberPicker.java:1437)
E/AndroidRuntime(22443):        at com.example.android.recyclerplayground.NumberPickerDialog.setPickerRange(NumberPickerDialog.java:48)
E/AndroidRuntime(22443):        at com.example.android.recyclerplayground.fragments.RecyclerFragment.onOptionsItemSelected(RecyclerFragment.java:70)
E/AndroidRuntime(22443):        at android.support.v4.app.Fragment.performOptionsItemSelected(Fragment.java:1894)
```