### PR TITLE
Replace ViewHolder's deprecated method getPosition() with getAdapterPosition()

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.+'
-    compile 'com.android.support:recyclerview-v7:21.0.+'
+    compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.android.support:recyclerview-v7:22.0.0'
 }

--- a/app/src/main/java/com/example/android/recyclerplayground/adapters/SimpleAdapter.java
+++ b/app/src/main/java/com/example/android/recyclerplayground/adapters/SimpleAdapter.java
@@ -91,7 +91,7 @@ public class SimpleAdapter extends RecyclerView.Adapter<SimpleAdapter.VerticalIt
     private void onItemHolderClick(VerticalItemHolder itemHolder) {
         if (mOnItemClickListener != null) {
             mOnItemClickListener.onItemClick(null, itemHolder.itemView,
-                    itemHolder.getPosition(), itemHolder.getItemId());
+                    itemHolder.getAdapterPosition(), itemHolder.getItemId());
         }
     }
 


### PR DESCRIPTION
Replace ViewHolder's deprecated method getPosition() with getAdapterPosition().

Updated appcompat and recyclerview to version v7-22.0.0.